### PR TITLE
Repository: Mbox: skip mails without a Message-ID

### DIFF
--- a/pypasta/Repository/Mbox.py
+++ b/pypasta/Repository/Mbox.py
@@ -253,7 +253,9 @@ class PubInbox(MailContainer):
 
         for hash in hashes:
             mail = self.get_mail_by_commit(hash)
-
+            if not mail['Message-ID']:
+                log.warning('No Message ID in commit %s' % hash)
+                continue
             message_id = mail['Message-ID'].replace(' ', '').strip()
             match = PubInbox.MESSAGE_ID_REGEX.match(message_id)
             if not match:


### PR DESCRIPTION
On the linux-mips-0 public inbox repository from lore.kernel.org,
`./pasta sync -mbox` failed with:

Traceback (most recent call last):
  File "./pasta", line 171, in <module>
    ret = main(deepcopy(sys.argv))
  File "./pasta", line 158, in main
    return sync(config, sub, argv)
  File "/home/lukas/repositories/github.com/lfd/PaStA/bin/pasta_sync.py", line 79, in sync
    repo.update_mbox(config)
  File "/home/lukas/repositories/github.com/lfd/PaStA/pypasta/Repository/Repository.py", line 240, in update_mbox
    self.mbox.update()
  File "/home/lukas/repositories/github.com/lfd/PaStA/pypasta/Repository/Mbox.py", line 426, in update
    pub.update()
  File "/home/lukas/repositories/github.com/lfd/PaStA/pypasta/Repository/Mbox.py", line 254, in update
    message_id = mail['Message-ID'].replace(' ', '').strip()
AttributeError: 'NoneType' object has no attribute 'replace'

There must be some emails with undetectable Message-IDs in the repository.
For now, simply skip those mails and do not add them to the mail index.

Signed-off-by: Lukas Bulwahn <lukas.bulwahn@gmail.com>