### PR TITLE
Remove `.idea`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea/
 __pycache__/
 *.pkl
 .Rhistory


### PR DESCRIPTION
As discussed, `.idea` is removed from the local `.gitignore` file and can be added by developers needing it to their global `.gitignore` file.
This can be achieved by executing `git config --global core.excludesfile ~/.gitignore`.