### PR TITLE
Rename attribute

### DIFF
--- a/pypasta/Repository/Mbox.py
+++ b/pypasta/Repository/Mbox.py
@@ -224,7 +224,7 @@ class PubInbox(MailContainer):
         return [self.get_blob(commit) for commit in commits]
 
     def update(self, nofetch):
-        log.info('Update list %s' % self.listname)
+        log.info('Update list %s' % self.listaddr)
         repo = git.Repo(self.d_repo)
         if not nofetch:
             for remote in repo.remotes:


### PR DESCRIPTION
The Attribute `self.listname` was renamed to `self.listaddr` in commit 9b3e0fae6.
In line 227 the renaming was forgotten.

Signed-off-by: Sebastian Duda <sebastian.duda@fau.de>