### PR TITLE
Added file_change_recipients command for pasta command line

### DIFF
--- a/bin/pasta_file_change_recipients.py
+++ b/bin/pasta_file_change_recipients.py
@@ -1,0 +1,95 @@
+"""
+PaStA - Patch Stack Analysis
+
+Author:
+  Shubhamkumar Pandey <b18194@students.iitmandi.ac.in>
+
+This work is licensed under the terms of the GNU GPL, version 2.  See
+the COPYING file in the top-level directory.
+"""
+
+import os
+import sys
+import argparse
+import pickle
+
+from tqdm import tqdm
+from os.path import join, exists
+from collections import defaultdict, Counter
+from logging import getLogger
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from pypasta import *
+from pypasta.LinuxMailCharacteristics import email_get_recipients
+from pypasta.Repository.Patch import Diff
+
+log = getLogger(__name__[-15:])
+
+
+def dump_pkl(config : Config, f_recipients_pkl : str = None):
+    repo = config.repo
+    RECIPIENTS = defaultdict(Counter)
+    for message_id in tqdm(repo.mbox.get_ids(time_window=config.mbox_time_window)):
+        patch = repo[message_id]
+        mail = repo.mbox.get_messages(message_id)[0]
+        recipients = email_get_recipients(mail)
+        for filename in patch.diff.affected:
+            for recipient in recipients:
+                RECIPIENTS[filename][recipient] += 1
+
+    if f_recipients_pkl:
+        pickle.dump(RECIPIENTS, open(f_recipients_pkl, 'wb'))
+
+    return RECIPIENTS
+
+
+def file_change_recipients(config : Config, argv : list):
+
+    parser = argparse.ArgumentParser(prog='predict', description='Get recipients of the patch file passed \
+                                    considering the files changed in the diff.')
+
+    parser.add_argument('--gen', dest='_generate', action="store_true",
+                        help='Generate file_change_recipient.pkl file as per current config')
+    parser.add_argument('--patch', dest='f_patch', metavar='patch', default=None, type=str,
+                        help='Path to the patch file')
+    parser.add_argument('--out', dest='f_out', metavar='outpath', type=str, default=None,
+                        help='Provide a path to output file containing the list of recipients related to \
+                        the patch')
+
+    args = parser.parse_args(argv)
+    repo = config.repo
+    repo.register_mbox(config)
+
+    f_recipients_pkl = join(config._project_root, 'resources/file_change_recipients.pkl')
+
+    if args._generate:
+        log.info('Evaluating recipients relation with respect to files changed')
+        if exists(f_recipients_pkl):
+            os.remove(f_recipients_pkl)
+        RECIPIENTS = dump_pkl(config, f_recipients_pkl)
+
+    elif exists(f_recipients_pkl):
+        RECIPIENTS = pickle.load(open(f_recipients_pkl, 'rb'))
+
+    else:
+        log.info('file_change_recipients.pkl was not found')
+        RECIPIENTS = dump_pkl(config, f_recipients_pkl)
+
+    if args.f_patch:
+        args.f_patch = join(os.getcwd(),args.f_patch)
+        diff = Diff(open(args.f_patch, 'r').readlines())
+
+        recipients = set()
+        for filename in diff.affected:
+            if filename in RECIPIENTS:
+                recipients |= set(RECIPIENTS[filename].keys())
+
+        if not args.f_out:
+            args.f_out = f'{args.f_patch}.recipients'
+
+        args.f_out = os.path.join(os.getcwd(), args.f_out)
+
+        with open(args.f_out, 'w') as f:
+            f.write('\n'.join(recipients))
+
+        log.info(f'The related recipient list for the patch is stored in {args.f_out}')

--- a/pasta
+++ b/pasta
@@ -45,6 +45,7 @@ from bin.pasta_upstream_duration import upstream_duration
 from bin.pasta_upstream_history import pasta_upstream_history
 from bin.pasta_web import web
 from bin.pasta_form_patchwork_relations import form_patchwork_relations
+from bin.pasta_file_change_recipients import file_change_recipients
 
 
 __author__ = 'Ralf Ramsauer'
@@ -88,6 +89,7 @@ def usage(me, exit_code=errno.EINVAL):
           '  ripup\n'
           '  upstream_history\n'
           '  web\n'
+          '  file_change_recipients\n'
           '\n'
           'If -c is not provided, PaStA will choose ./config as config file\n'
           '\n'
@@ -184,6 +186,8 @@ def main(argv):
         return upstream_duration(config, argv)
     elif sub == 'web':
         return web(config, argv)
+    elif sub == 'file_change_recipients':
+        return file_change_recipients(config, argv)
     else:
         print('Unknown command: %s' % sub)
         usage(me)


### PR DESCRIPTION
I have added a command using the relations between the files changed and recipients for patches to give all the possible recipients for a patch.
[sample.patch](https://pastebin.com/HfGeN3mP) used.

Working proof of the command
```
(lfd-pasta) dark_matter@DarkMatter ~/l/l/PaStA (stream-3)> 
./pasta file_change_recipients --gen
2020-08-03 16:19:38,325 PaStA           INFO     Cmdline: ./pasta file_change_recipients --gen
2020-08-03 16:19:38,325 pypasta.Config  INFO     Loading configuration: linux
2020-08-03 16:19:38,366 Repository.Mbox INFO     Loading mailbox subsystem
2020-08-03 16:19:38,369 Repository.Mbox INFO       ↪ loaded invalid mail index: found 4669 invalid mails
2020-08-03 16:19:38,369 Repository.Mbox INFO     Loading public inboxes
2020-08-03 16:19:40,014 Repository.Mbox INFO       ↪ loaded mail index for alsa-devel@alsa-project.org (shard 0): found 213500 mails
2020-08-03 16:19:40,427 ange_recipients INFO     Evaluating recipients relation with respect to files changed
100%|██████████████████████████████████████| 4186/4186 [00:06<00:00, 675.86it/s]
2020-08-03 16:19:46,814 PaStA           INFO     Shutting down
(lfd-pasta) dark_matter@DarkMatter ~/l/l/PaStA (stream-3)> 
./pasta file_change_recipients --patch sample.patch --out outfile.lst
2020-08-03 16:24:18,314 PaStA           INFO     Cmdline: ./pasta file_change_recipients --patch sample.patch --out outfile.lst
2020-08-03 16:24:18,314 pypasta.Config  INFO     Loading configuration: linux
2020-08-03 16:24:18,357 Repository.Mbox INFO     Loading mailbox subsystem
2020-08-03 16:24:18,359 Repository.Mbox INFO       ↪ loaded invalid mail index: found 4669 invalid mails
2020-08-03 16:24:18,359 Repository.Mbox INFO     Loading public inboxes
2020-08-03 16:24:19,973 Repository.Mbox INFO       ↪ loaded mail index for alsa-devel@alsa-project.org (shard 0): found 213500 mails
2020-08-03 16:24:20,398 ange_recipients INFO     The related recipient list for the patch is stored in /home/dark_matter/linux_work/lfd-pasta/PaStA/outfile.lst
2020-08-03 16:24:20,444 PaStA           INFO     Shutting down
(lfd-pasta) dark_matter@DarkMatter ~/l/l/PaStA (stream-3)> cat outfile.lst
linux-kernel@vger.kernel.org
pavan.k.s@intel.com
linux-pm@vger.kernel.org
cezary.rojewski@intel.com
s@alsa-project.org
lgirdwood@gmail.com
liam.r.girdwood@linux.intel.com
mateusz.gorski@linux.intel.com
kuninori.morimoto.gx@renesas.com
broonie@kernel.org
andriy.shevchenko@linux.intel.com
tiwai@suse.com
pierre-louis.bossart@linux.intel.com
amit.kucheria@linaro.org
yang.jie@linux.intel.com
alsa-devel@alsa-project.org⏎                                                    
(lfd-pasta) dark_matter@DarkMatter ~/l/l/PaStA (stream-3)> 
```

Signed-off-by: Shubhamkumar Pandey <b18194@students.iitmandi.ac.in>